### PR TITLE
Depend on apache-httpcomponent plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG
 Master (unreleased)
 -----
 * Fix compatibility with PCT [#4](https://github.com/jenkinsci/kubernetes-credentials-plugin/pull/4)
+* Require Jenkins core 2.60.3
+* Remove packaged apache-httpclient and depend on [apache-httpcomponents-client-4-api-plugin](https://github.com/jenkinsci/apache-httpcomponents-client-4-api-plugin) instead.
 
 0.3.1
 -----

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.6</version>
+    <version>3.20</version>
   </parent>
 
   <groupId>org.jenkinsci.plugins</groupId>
@@ -39,9 +39,7 @@
     <java.level>8</java.level>
 
     <!-- dependency versions -->
-    <httpclient.version>4.5.1</httpclient.version>
-    <jackson.version>2.5.0</jackson.version>
-    <jenkins.version>2.32.1</jenkins.version>
+    <jenkins.version>2.60.3</jenkins.version>
 
     <slf4j.version>1.7.25</slf4j.version>
 
@@ -53,9 +51,9 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
-      <version>${httpclient.version}</version>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>apache-httpcomponents-client-4-api</artifactId>
+      <version>4.5.5-3.0</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
* Update parent POM
* Bump required core to 2.60.3 (already 1 year old)
* Replace dependency to httpclient lib by the corresponding library
plugin