### PR TITLE
Plugin description should live in index.jelly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,6 @@
   <artifactId>kubernetes-credentials</artifactId>
   <version>0.4.1-SNAPSHOT</version>
   <name>Kubernetes Credentials Plugin</name>
-  <description>Common classes for Kubernetes credentials</description>
   <packaging>hpi</packaging>
 
   <scm>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<div>
+    Common classes for Kubernetes credentials
+</div>


### PR DESCRIPTION
I recently noticed that in an installation of a CloudBees distribution of Jenkins, this was the only plugin in `/pluginManager/installed` which lacked a proper blurb in the table. That is because it was missing the required `index` view.

As in https://github.com/jenkinsci/archetypes/pull/38, `<description>` can then be omitted.