### PR TITLE
Update URL for plugins.jenkins.io

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,7 @@
   <artifactId>kubernetes-credentials</artifactId>
   <version>${revision}${changelist}</version>
   <name>Kubernetes Credentials Plugin</name>
+  <url>https://github.com/jenkinsci/kubernetes-credentials-plugin/</url>
   <packaging>hpi</packaging>
 
   <scm>


### PR DESCRIPTION
Update for pom.xml that enables docs on https://plugins.jenkins.io/kubernetes-credentials

#hacktoberfest