### PR TITLE
Remove additional carrier return when reading fixture

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/kubernetes/auth/impl/KubernetesAuthKeystoreTest.java
+++ b/src/test/java/org/jenkinsci/plugins/kubernetes/auth/impl/KubernetesAuthKeystoreTest.java
@@ -36,7 +36,8 @@ public class KubernetesAuthKeystoreTest {
     }
 
     private String readFile(String name) throws IOException {
-        return new String(IOUtils.toByteArray(getClass().getResourceAsStream(name)));
+        // Replacement is needed for getting the right content on Windows platform
+        return new String(IOUtils.toByteArray(getClass().getResourceAsStream(name))).replaceAll("\\r\\n", "\n");
     }
 
     private static KeyStore loadKeyStore(InputStream inputStream, char[] password) throws CertificateException, NoSuchAlgorithmException, IOException, KeyStoreException {


### PR DESCRIPTION
Superseeds https://github.com/jenkinsci/kubernetes-credentials-plugin/pull/15
Fixes the tests on Windows