### PR TITLE
Give access to ConfigBuilder

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/kubernetes/auth/KubernetesAuth.java
+++ b/src/main/java/org/jenkinsci/plugins/kubernetes/auth/KubernetesAuth.java
@@ -23,4 +23,5 @@ public interface KubernetesAuth {
      * @throws KubernetesAuthException if something fails while dealing with credentials
      */
     String buildKubeConfig(KubernetesAuthConfig config) throws JsonProcessingException, KubernetesAuthException;
+    io.fabric8.kubernetes.api.model.ConfigBuilder buildConfigBuilder(KubernetesAuthConfig config,String context,String clusterName,String username) throws KubernetesAuthException;
 }

--- a/src/main/java/org/jenkinsci/plugins/kubernetes/auth/impl/KubernetesAuthKubeconfig.java
+++ b/src/main/java/org/jenkinsci/plugins/kubernetes/auth/impl/KubernetesAuthKubeconfig.java
@@ -1,6 +1,7 @@
 package org.jenkinsci.plugins.kubernetes.auth.impl;
 
 import io.fabric8.kubernetes.client.ConfigBuilder;
+import io.fabric8.kubernetes.client.internal.KubeConfigUtils;
 import org.jenkinsci.plugins.kubernetes.auth.KubernetesAuth;
 import org.jenkinsci.plugins.kubernetes.auth.KubernetesAuthConfig;
 import org.jenkinsci.plugins.kubernetes.auth.KubernetesAuthException;
@@ -28,6 +29,15 @@ public class KubernetesAuthKubeconfig implements KubernetesAuth {
             return new ConfigBuilder(io.fabric8.kubernetes.client.Config.fromKubeconfig(getKubeconfig()));
         } catch (IOException e) {
             throw new KubernetesAuthException(e);
+        }
+    }
+
+    public io.fabric8.kubernetes.api.model.ConfigBuilder buildConfigBuilder(KubernetesAuthConfig config, String context, String clusterName, String username) throws KubernetesAuthException {
+        try {
+            io.fabric8.kubernetes.api.model.Config kubeConfig = KubeConfigUtils.parseConfigFromString(getKubeconfig());
+            return new io.fabric8.kubernetes.api.model.ConfigBuilder(kubeConfig);
+        } catch (IOException e) {
+            throw new KubernetesAuthException(e.getMessage(), e);
         }
     }
 


### PR DESCRIPTION
Give access to `ConfigBuilder` to make it easier for other plugins to modify the configuration before it's generated.