### PR TITLE
some plugins could be optional

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,25 +85,30 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
     </dependency>
-    <!-- to use StringCredentialsImpl for tokens -->
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>plain-credentials</artifactId>
-    </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>authentication-tokens</artifactId>
       <version>1.3</version>
     </dependency>
+
+    <!-- optional plugins -->
+    <!-- to use StringCredentialsImpl for tokens -->
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>plain-credentials</artifactId>
+      <optional>true</optional>
+    </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>google-oauth-plugin</artifactId>
       <version>0.8</version>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>docker-commons</artifactId>
       <version>1.14</version>
+      <optional>true</optional>
     </dependency>
 
   </dependencies>

--- a/src/main/java/org/jenkinsci/plugins/kubernetes/tokensource/DockerServerCredentialsTokenSource.java
+++ b/src/main/java/org/jenkinsci/plugins/kubernetes/tokensource/DockerServerCredentialsTokenSource.java
@@ -7,7 +7,7 @@ import jenkins.authentication.tokens.api.AuthenticationTokenSource;
 import org.jenkinsci.plugins.docker.commons.credentials.DockerServerCredentials;
 import org.jenkinsci.plugins.kubernetes.auth.impl.KubernetesAuthCertificate;
 
-@Extension
+@Extension(optional = true)
 public class DockerServerCredentialsTokenSource extends AuthenticationTokenSource<KubernetesAuthCertificate, DockerServerCredentials> {
     public DockerServerCredentialsTokenSource() { super(KubernetesAuthCertificate.class, DockerServerCredentials.class); }
 

--- a/src/main/java/org/jenkinsci/plugins/kubernetes/tokensource/FileCredentialsTokenSource.java
+++ b/src/main/java/org/jenkinsci/plugins/kubernetes/tokensource/FileCredentialsTokenSource.java
@@ -12,7 +12,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 
-@Extension
+@Extension(optional = true)
 public class FileCredentialsTokenSource extends AuthenticationTokenSource<KubernetesAuthKubeconfig, FileCredentials> {
     public FileCredentialsTokenSource() {
         super(KubernetesAuthKubeconfig.class, FileCredentials.class);

--- a/src/main/java/org/jenkinsci/plugins/kubernetes/tokensource/GoogleRobotCredentialsTokenSource.java
+++ b/src/main/java/org/jenkinsci/plugins/kubernetes/tokensource/GoogleRobotCredentialsTokenSource.java
@@ -13,7 +13,7 @@ import java.util.Collections;
 /**
  * Converts {@link GoogleRobotCredentials} to {@link String} token.
  */
-@Extension
+@Extension(optional = true)
 public class GoogleRobotCredentialsTokenSource extends AuthenticationTokenSource<KubernetesAuthToken, GoogleRobotCredentials>  {
     public GoogleRobotCredentialsTokenSource() {
         super(KubernetesAuthToken.class, GoogleRobotCredentials.class);

--- a/src/main/java/org/jenkinsci/plugins/kubernetes/tokensource/StringCredentialsTokenSource.java
+++ b/src/main/java/org/jenkinsci/plugins/kubernetes/tokensource/StringCredentialsTokenSource.java
@@ -6,7 +6,7 @@ import jenkins.authentication.tokens.api.AuthenticationTokenSource;
 import org.jenkinsci.plugins.kubernetes.auth.impl.KubernetesAuthToken;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 
-@Extension
+@Extension(optional = true)
 public class StringCredentialsTokenSource extends AuthenticationTokenSource<KubernetesAuthToken, StringCredentials> {
     public StringCredentialsTokenSource() {
         super(KubernetesAuthToken.class, StringCredentials.class);


### PR DESCRIPTION
plain-credentials, google-oauth-plugin and docker-commons could be optional.

If I don't use GKE, I should not be forced to install google-oauth-plugin.

I tried to see how to add test but I couldn't find a way to test that the plugin behaves normally with or without these optionals plugins.