### PR TITLE
Compatibility with Jenkins 2.235 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.20</version>
+    <version>4.2</version>
   </parent>
 
   <groupId>org.jenkinsci.plugins</groupId>
@@ -41,17 +41,11 @@
     <java.level>8</java.level>
 
     <!-- dependency versions -->
-    <jenkins.version>2.176.1</jenkins.version>
-
-    <slf4j.version>1.7.26</slf4j.version>
-
-    <!-- jenkins plugins versions -->
-    <jenkins-structs.version>1.19</jenkins-structs.version>
+    <jenkins.version>2.204.6</jenkins.version>
 
     <!-- maven plugins versions -->
     <maven-coveralls.version>4.3.0</maven-coveralls.version>
     <maven-jacoco.version>0.8.1</maven-jacoco.version>
-    <kubernetes-client.version>4.3.0</kubernetes-client.version>
 
   </properties>
 
@@ -59,25 +53,18 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>kubernetes-client-api</artifactId>
-      <version>1.0.0</version>
+      <version>4.9.2-2</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>jackson2-api</artifactId>
-      <version>2.9.9</version>
+      <version>2.11.0</version>
     </dependency>
 
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>apache-httpcomponents-client-4-api</artifactId>
       <version>4.5.5-3.0</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>${slf4j.version}</version>
-      <scope>provided</scope>
     </dependency>
 
     <!-- required plugins -->
@@ -113,15 +100,10 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom</artifactId>
-        <version>2.176.2</version>
+        <artifactId>bom-2.204.x</artifactId>
+        <version>9</version>
         <scope>import</scope>
         <type>pom</type>
-      </dependency>
-      <dependency>
-        <groupId>commons-io</groupId>
-        <artifactId>commons-io</artifactId>
-        <version>2.6</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/src/main/java/org/jenkinsci/plugins/kubernetes/credentials/HttpClientWithTLSOptionsFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/kubernetes/credentials/HttpClientWithTLSOptionsFactory.java
@@ -87,7 +87,7 @@ public class HttpClientWithTLSOptionsFactory {
             } else if (caCertData != null) {
                 builder.setSSLSocketFactory(getVerifyCertSSLFactory(uri.getHost(), caCertData));
             }
-        } catch (CertificateException | NoSuchAlgorithmException | KeyStoreException | KeyManagementException | IOException e) {
+        } catch (CertificateException | NoSuchAlgorithmException | KeyStoreException | KeyManagementException | IOException | IllegalArgumentException e) {
             throw new TLSConfigurationError(e);
         }
 


### PR DESCRIPTION
Subsumes #21

Newer Jenkins pulls commons-codec 1.14 (from 1.12) which has slightly
different exception raised when certificate is invalid.