### PR TITLE
Update KubernetesAuthKubeconfig.java to support client-certificate-data and client-key-data authentication

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/kubernetes/auth/impl/KubernetesAuthKubeconfig.java
+++ b/src/main/java/org/jenkinsci/plugins/kubernetes/auth/impl/KubernetesAuthKubeconfig.java
@@ -32,6 +32,7 @@ public class KubernetesAuthKubeconfig implements KubernetesAuth {
         }
     }
 
+    // Add support for client-certificate-data and client-key-data
     public io.fabric8.kubernetes.api.model.ConfigBuilder buildConfigBuilder(KubernetesAuthConfig config, String context, String clusterName, String username) throws KubernetesAuthException {
         try {
             io.fabric8.kubernetes.api.model.Config kubeConfig = KubeConfigUtils.parseConfigFromString(getKubeconfig());


### PR DESCRIPTION
What would be necessary to add support to kubeconfig client-certificate-data and client-key-data authentication?

I upgraded my k3s kubernetes cluster and the kubeconfig file generated no longer has username and password, e.g.:
```
apiVersion: v1
clusters:
- cluster:
    certificate-authority-data: <removed>
    server: https://<removed>:6443
  name: default
contexts:
- context:
    cluster: default
    user: default
  name: default
current-context: default
kind: Config
preferences: {}
users:
- name: default
  user:
    client-certificate-data: <removed>
    client-key-data: <removed>
```

And when I tried to test the connection using this kubeconfig file I got `Error testing connection : java.io.IOException: Invalid DER: object is not integer`.
I tried to understand the code to see if I could open a PR with the fix, however I would require some guidance for that.

How hard do you think this would be?