### PR TITLE
Suppressing OpenShiftBearerTokenCredentialTest.testValidTokenExtraction

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/kubernetes/credentials/OpenShiftBearerTokenCredentialTest.java
+++ b/src/test/java/org/jenkinsci/plugins/kubernetes/credentials/OpenShiftBearerTokenCredentialTest.java
@@ -7,6 +7,7 @@ import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -95,13 +96,13 @@ public class OpenShiftBearerTokenCredentialTest {
         t.getToken(server.getURI() + "bad-location", null, true);
     }
 
+    @Ignore("TODO known to flake")
     @Test
     public void testValidTokenExtraction() throws OpenShiftBearerTokenCredentialImpl.TokenResponseError {
         OpenShiftBearerTokenCredentialImpl.Token token = OpenShiftBearerTokenCredentialImpl.extractTokenFromLocation("https://master.cluster.local:8443/oauth/token/display#access_token=VO4dAgNGLnX5MGYu_wXau8au2Rw0QAqnwq8AtrLkMfU&expires_in=86400&token_type=bearer");
         assertEquals("VO4dAgNGLnX5MGYu_wXau8au2Rw0QAqnwq8AtrLkMfU", token.value);
 
         // We are optimistic here and expect the test to run in less than a second.
-        // TODO: Improve
         assertEquals(86100000, token.expire - System.currentTimeMillis());
     }
 


### PR DESCRIPTION
As part of a `plugin-compat-tester` run across numerous plugins, I noticed this test flaking repeatedly:

```
java.lang.AssertionError: expected:<86100000> but was:<86099999>
	at org.junit.Assert.fail(Assert.java:89)
	at org.junit.Assert.failNotEquals(Assert.java:835)
	at org.junit.Assert.assertEquals(Assert.java:647)
	at org.junit.Assert.assertEquals(Assert.java:633)
	at org.jenkinsci.plugins.kubernetes.credentials.OpenShiftBearerTokenCredentialTest.testValidTokenExtraction(OpenShiftBearerTokenCredentialTest.java:105)
```

Not sure what it was supposed to be verifying, but needs to be disabled unless and until it can be rewritten to pass reliably.