### PR TITLE
Codescanning and deprecations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>docker-commons</artifactId>
-      <version>1.14</version>
+      <version>1.15</version>
       <optional>true</optional>
     </dependency>
     <dependency>

--- a/src/main/java/org/jenkinsci/plugins/kubernetes/auth/impl/KubernetesAuthCertificate.java
+++ b/src/main/java/org/jenkinsci/plugins/kubernetes/auth/impl/KubernetesAuthCertificate.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.kubernetes.auth.impl;
 
+import hudson.util.Secret;
 import io.fabric8.kubernetes.api.model.AuthInfoBuilder;
 import io.fabric8.kubernetes.client.ConfigBuilder;
 import org.jenkinsci.plugins.kubernetes.auth.KubernetesAuth;
@@ -9,9 +10,9 @@ import org.jenkinsci.plugins.kubernetes.credentials.Utils;
 public class KubernetesAuthCertificate extends AbstractKubernetesAuth implements KubernetesAuth {
     private final String certificate;
 
-    private final String key;
+    private final Secret key;
 
-    public KubernetesAuthCertificate(String certificate, String key) {
+    public KubernetesAuthCertificate(String certificate, Secret key) {
         this.certificate = certificate;
         this.key = key;
     }
@@ -20,14 +21,14 @@ public class KubernetesAuthCertificate extends AbstractKubernetesAuth implements
     public AuthInfoBuilder decorate(AuthInfoBuilder builder, KubernetesAuthConfig config) {
         return builder
                 .withClientCertificateData(Utils.encodeBase64(certificate))
-                .withClientKeyData(Utils.encodeBase64(key));
+                .withClientKeyData(Utils.encodeBase64(getKey()));
     }
 
     @Override
     public ConfigBuilder decorate(ConfigBuilder builder, KubernetesAuthConfig config) {
         return builder
                 .withClientCertData(Utils.encodeBase64(certificate))
-                .withClientKeyData(Utils.encodeBase64(key));
+                .withClientKeyData(Utils.encodeBase64(getKey()));
     }
 
     public String getCertificate() {
@@ -35,6 +36,6 @@ public class KubernetesAuthCertificate extends AbstractKubernetesAuth implements
     }
 
     public String getKey() {
-        return key;
+        return key.getPlainText();
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/kubernetes/auth/impl/KubernetesAuthKeystore.java
+++ b/src/main/java/org/jenkinsci/plugins/kubernetes/auth/impl/KubernetesAuthKeystore.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.kubernetes.auth.impl;
 
+import hudson.util.Secret;
 import io.fabric8.kubernetes.api.model.AuthInfoBuilder;
 import io.fabric8.kubernetes.client.ConfigBuilder;
 import org.jenkinsci.plugins.kubernetes.auth.KubernetesAuth;
@@ -21,9 +22,9 @@ import java.security.cert.CertificateEncodingException;
 public class KubernetesAuthKeystore extends AbstractKubernetesAuth implements KubernetesAuth {
     private KeyStore keyStore;
 
-    private final String passPhrase;
+    private final Secret passPhrase;
 
-    public KubernetesAuthKeystore(@Nonnull KeyStore keyStore, String passPhrase) {
+    public KubernetesAuthKeystore(@Nonnull KeyStore keyStore, Secret passPhrase) {
         this.keyStore = keyStore;
         this.passPhrase = passPhrase;
     }
@@ -33,7 +34,7 @@ public class KubernetesAuthKeystore extends AbstractKubernetesAuth implements Ku
         try {
             String alias = keyStore.aliases().nextElement();
             // Get private key using passphrase
-            Key key = keyStore.getKey(alias, passPhrase.toCharArray());
+            Key key = keyStore.getKey(alias, getPassPhrase().toCharArray());
             return builder
                     .withClientCertificateData(Utils.encodeCertificate(keyStore.getCertificate(alias)))
                     .withClientKeyData(Utils.encodeKey(key));
@@ -47,7 +48,7 @@ public class KubernetesAuthKeystore extends AbstractKubernetesAuth implements Ku
         try {
             String alias = keyStore.aliases().nextElement();
             // Get private key using passphrase
-            Key key = keyStore.getKey(alias, passPhrase.toCharArray());
+            Key key = keyStore.getKey(alias, getPassPhrase().toCharArray());
             return builder
                     .withClientCertData(Utils.encodeCertificate(keyStore.getCertificate(alias)))
                     .withClientKeyData(Utils.encodeKey(key));
@@ -61,6 +62,6 @@ public class KubernetesAuthKeystore extends AbstractKubernetesAuth implements Ku
     }
 
     public String getPassPhrase() {
-        return passPhrase;
+        return passPhrase.getPlainText();
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/kubernetes/auth/impl/KubernetesAuthUsernamePassword.java
+++ b/src/main/java/org/jenkinsci/plugins/kubernetes/auth/impl/KubernetesAuthUsernamePassword.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.kubernetes.auth.impl;
 
+import hudson.util.Secret;
 import io.fabric8.kubernetes.api.model.AuthInfoBuilder;
 import io.fabric8.kubernetes.client.ConfigBuilder;
 import org.jenkinsci.plugins.kubernetes.auth.KubernetesAuth;
@@ -11,10 +12,10 @@ import org.jenkinsci.plugins.kubernetes.auth.KubernetesAuthException;
  */
 public class KubernetesAuthUsernamePassword extends AbstractKubernetesAuth implements KubernetesAuth {
     private final String username;
-    private final String password;
+    private final Secret password;
 
 
-    public KubernetesAuthUsernamePassword(String username, String password) {
+    public KubernetesAuthUsernamePassword(String username, Secret password) {
         this.username = username;
         this.password = password;
     }
@@ -38,6 +39,6 @@ public class KubernetesAuthUsernamePassword extends AbstractKubernetesAuth imple
     }
 
     public String getPassword() {
-        return password;
+        return password.getPlainText();
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/kubernetes/credentials/FileSystemServiceAccountCredential.java
+++ b/src/main/java/org/jenkinsci/plugins/kubernetes/credentials/FileSystemServiceAccountCredential.java
@@ -2,6 +2,7 @@ package org.jenkinsci.plugins.kubernetes.credentials;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.FileUtils;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
@@ -38,7 +39,7 @@ public class FileSystemServiceAccountCredential extends BaseStandardCredentials
     @SuppressFBWarnings("DMI_HARDCODED_ABSOLUTE_FILENAME")
     public Secret getSecret() {
         try {
-            return Secret.fromString(FileUtils.readFileToString(new File(SERVICEACCOUNT_TOKEN_PATH)));
+            return Secret.fromString(FileUtils.readFileToString(new File(SERVICEACCOUNT_TOKEN_PATH), StandardCharsets.UTF_8));
         } catch (IOException e) {
             return Secret.fromString(null);
         }

--- a/src/main/java/org/jenkinsci/plugins/kubernetes/tokensource/DockerServerCredentialsTokenSource.java
+++ b/src/main/java/org/jenkinsci/plugins/kubernetes/tokensource/DockerServerCredentialsTokenSource.java
@@ -1,19 +1,20 @@
 package org.jenkinsci.plugins.kubernetes.tokensource;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import jenkins.authentication.tokens.api.AuthenticationTokenException;
 import jenkins.authentication.tokens.api.AuthenticationTokenSource;
 import org.jenkinsci.plugins.docker.commons.credentials.DockerServerCredentials;
 import org.jenkinsci.plugins.kubernetes.auth.impl.KubernetesAuthCertificate;
 
+import javax.annotation.Nonnull;
+
 @Extension(optional = true)
 public class DockerServerCredentialsTokenSource extends AuthenticationTokenSource<KubernetesAuthCertificate, DockerServerCredentials> {
     public DockerServerCredentialsTokenSource() { super(KubernetesAuthCertificate.class, DockerServerCredentials.class); }
 
-    @NonNull
+    @Nonnull
     @Override
-    public KubernetesAuthCertificate convert(@NonNull DockerServerCredentials credential) throws AuthenticationTokenException {
+    public KubernetesAuthCertificate convert(@Nonnull DockerServerCredentials credential) throws AuthenticationTokenException {
         return new KubernetesAuthCertificate(credential.getClientCertificate(), credential.getClientKeySecret());
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/kubernetes/tokensource/DockerServerCredentialsTokenSource.java
+++ b/src/main/java/org/jenkinsci/plugins/kubernetes/tokensource/DockerServerCredentialsTokenSource.java
@@ -14,6 +14,6 @@ public class DockerServerCredentialsTokenSource extends AuthenticationTokenSourc
     @NonNull
     @Override
     public KubernetesAuthCertificate convert(@NonNull DockerServerCredentials credential) throws AuthenticationTokenException {
-        return new KubernetesAuthCertificate(credential.getClientCertificate(), credential.getClientKey());
+        return new KubernetesAuthCertificate(credential.getClientCertificate(), credential.getClientKeySecret());
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/kubernetes/tokensource/FileCredentialsTokenSource.java
+++ b/src/main/java/org/jenkinsci/plugins/kubernetes/tokensource/FileCredentialsTokenSource.java
@@ -1,6 +1,5 @@
 package org.jenkinsci.plugins.kubernetes.tokensource;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import jenkins.authentication.tokens.api.AuthenticationTokenException;
 import jenkins.authentication.tokens.api.AuthenticationTokenSource;
@@ -8,6 +7,7 @@ import org.apache.commons.io.IOUtils;
 import org.jenkinsci.plugins.kubernetes.auth.impl.KubernetesAuthKubeconfig;
 import org.jenkinsci.plugins.plaincredentials.FileCredentials;
 
+import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -18,9 +18,9 @@ public class FileCredentialsTokenSource extends AuthenticationTokenSource<Kubern
         super(KubernetesAuthKubeconfig.class, FileCredentials.class);
     }
 
-    @NonNull
+    @Nonnull
     @Override
-    public KubernetesAuthKubeconfig convert(@NonNull FileCredentials credential) throws AuthenticationTokenException {
+    public KubernetesAuthKubeconfig convert(@Nonnull FileCredentials credential) throws AuthenticationTokenException {
         try (InputStream is = credential.getContent()) {
             return new KubernetesAuthKubeconfig(IOUtils.toString(is, StandardCharsets.UTF_8));
         } catch (IOException e) {

--- a/src/main/java/org/jenkinsci/plugins/kubernetes/tokensource/GoogleRobotCredentialsTokenSource.java
+++ b/src/main/java/org/jenkinsci/plugins/kubernetes/tokensource/GoogleRobotCredentialsTokenSource.java
@@ -2,11 +2,11 @@ package org.jenkinsci.plugins.kubernetes.tokensource;
 
 import com.google.jenkins.plugins.credentials.oauth.GoogleOAuth2ScopeRequirement;
 import com.google.jenkins.plugins.credentials.oauth.GoogleRobotCredentials;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import jenkins.authentication.tokens.api.AuthenticationTokenSource;
 import org.jenkinsci.plugins.kubernetes.auth.impl.KubernetesAuthToken;
 
+import javax.annotation.Nonnull;
 import java.util.Collection;
 import java.util.Collections;
 
@@ -19,9 +19,9 @@ public class GoogleRobotCredentialsTokenSource extends AuthenticationTokenSource
         super(KubernetesAuthToken.class, GoogleRobotCredentials.class);
     }
 
-    @NonNull
+    @Nonnull
     @Override
-    public KubernetesAuthToken convert(@NonNull GoogleRobotCredentials credential) {
+    public KubernetesAuthToken convert(@Nonnull GoogleRobotCredentials credential) {
         return new KubernetesAuthToken((serviceAddress, caCertData, skipTlsVerify) -> credential.getAccessToken(new GoogleOAuth2ScopeRequirement() {
             @Override
             public Collection<String> getScopes() {

--- a/src/main/java/org/jenkinsci/plugins/kubernetes/tokensource/StandardCertificateCredentialsTokenSource.java
+++ b/src/main/java/org/jenkinsci/plugins/kubernetes/tokensource/StandardCertificateCredentialsTokenSource.java
@@ -17,6 +17,6 @@ public class StandardCertificateCredentialsTokenSource extends AuthenticationTok
     @NonNull
     @Override
     public KubernetesAuthKeystore convert(@NonNull StandardCertificateCredentials credential) throws AuthenticationTokenException {
-        return new KubernetesAuthKeystore(credential.getKeyStore(), Secret.toString(credential.getPassword()));
+        return new KubernetesAuthKeystore(credential.getKeyStore(), credential.getPassword());
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/kubernetes/tokensource/StandardCertificateCredentialsTokenSource.java
+++ b/src/main/java/org/jenkinsci/plugins/kubernetes/tokensource/StandardCertificateCredentialsTokenSource.java
@@ -1,12 +1,12 @@
 package org.jenkinsci.plugins.kubernetes.tokensource;
 
 import com.cloudbees.plugins.credentials.common.StandardCertificateCredentials;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
-import hudson.util.Secret;
 import jenkins.authentication.tokens.api.AuthenticationTokenException;
 import jenkins.authentication.tokens.api.AuthenticationTokenSource;
 import org.jenkinsci.plugins.kubernetes.auth.impl.KubernetesAuthKeystore;
+
+import javax.annotation.Nonnull;
 
 @Extension
 public class StandardCertificateCredentialsTokenSource extends AuthenticationTokenSource<KubernetesAuthKeystore, StandardCertificateCredentials> {
@@ -14,9 +14,9 @@ public class StandardCertificateCredentialsTokenSource extends AuthenticationTok
         super(KubernetesAuthKeystore.class, StandardCertificateCredentials.class);
     }
 
-    @NonNull
+    @Nonnull
     @Override
-    public KubernetesAuthKeystore convert(@NonNull StandardCertificateCredentials credential) throws AuthenticationTokenException {
+    public KubernetesAuthKeystore convert(@Nonnull StandardCertificateCredentials credential) throws AuthenticationTokenException {
         return new KubernetesAuthKeystore(credential.getKeyStore(), credential.getPassword());
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/kubernetes/tokensource/StringCredentialsTokenSource.java
+++ b/src/main/java/org/jenkinsci/plugins/kubernetes/tokensource/StringCredentialsTokenSource.java
@@ -1,10 +1,11 @@
 package org.jenkinsci.plugins.kubernetes.tokensource;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import jenkins.authentication.tokens.api.AuthenticationTokenSource;
 import org.jenkinsci.plugins.kubernetes.auth.impl.KubernetesAuthToken;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
+
+import javax.annotation.Nonnull;
 
 @Extension(optional = true)
 public class StringCredentialsTokenSource extends AuthenticationTokenSource<KubernetesAuthToken, StringCredentials> {
@@ -12,9 +13,9 @@ public class StringCredentialsTokenSource extends AuthenticationTokenSource<Kube
         super(KubernetesAuthToken.class, StringCredentials.class);
     }
 
-    @NonNull
+    @Nonnull
     @Override
-    public KubernetesAuthToken convert(@NonNull StringCredentials credential) {
+    public KubernetesAuthToken convert(@Nonnull StringCredentials credential) {
         return new KubernetesAuthToken((serviceAddress, caCertData, skipTlsVerify) -> credential.getSecret().getPlainText());
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/kubernetes/tokensource/UsernamePasswordCredentialsTokenSource.java
+++ b/src/main/java/org/jenkinsci/plugins/kubernetes/tokensource/UsernamePasswordCredentialsTokenSource.java
@@ -1,7 +1,6 @@
 package org.jenkinsci.plugins.kubernetes.tokensource;
 
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import jenkins.authentication.tokens.api.AuthenticationTokenException;
 import jenkins.authentication.tokens.api.AuthenticationTokenSource;
@@ -10,15 +9,17 @@ import org.jenkinsci.plugins.kubernetes.auth.impl.KubernetesAuthToken;
 import org.jenkinsci.plugins.kubernetes.auth.impl.KubernetesAuthUsernamePassword;
 import org.jenkinsci.plugins.kubernetes.credentials.TokenProducer;
 
+import javax.annotation.Nonnull;
+
 @Extension
 public class UsernamePasswordCredentialsTokenSource extends AuthenticationTokenSource<KubernetesAuth, StandardUsernamePasswordCredentials> {
     public UsernamePasswordCredentialsTokenSource() {
         super(KubernetesAuth.class, StandardUsernamePasswordCredentials.class);
     }
 
-    @NonNull
+    @Nonnull
     @Override
-    public KubernetesAuth convert(@NonNull StandardUsernamePasswordCredentials credential) throws AuthenticationTokenException {
+    public KubernetesAuth convert(@Nonnull StandardUsernamePasswordCredentials credential) throws AuthenticationTokenException {
         if (credential instanceof TokenProducer) {
             return new KubernetesAuthToken((TokenProducer) credential);
         } else {

--- a/src/main/java/org/jenkinsci/plugins/kubernetes/tokensource/UsernamePasswordCredentialsTokenSource.java
+++ b/src/main/java/org/jenkinsci/plugins/kubernetes/tokensource/UsernamePasswordCredentialsTokenSource.java
@@ -24,7 +24,7 @@ public class UsernamePasswordCredentialsTokenSource extends AuthenticationTokenS
         } else {
             return new KubernetesAuthUsernamePassword(
                     credential.getUsername(),
-                    credential.getPassword().getPlainText()
+                    credential.getPassword()
             );
         }
     }

--- a/src/test/java/org/jenkinsci/plugins/kubernetes/auth/impl/KubernetesAuthCertificateTest.java
+++ b/src/test/java/org/jenkinsci/plugins/kubernetes/auth/impl/KubernetesAuthCertificateTest.java
@@ -1,28 +1,34 @@
 package org.jenkinsci.plugins.kubernetes.auth.impl;
 
+import hudson.util.Secret;
 import io.fabric8.kubernetes.client.utils.Serialization;
 import org.jenkinsci.plugins.kubernetes.auth.KubernetesAuthConfig;
 import org.jenkinsci.plugins.kubernetes.auth.impl.KubernetesAuthCertificate;
 import org.jenkinsci.plugins.kubernetes.credentials.Utils;
+import org.junit.Rule;
 import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
 
 import static org.junit.Assert.assertEquals;
 
 public class KubernetesAuthCertificateTest {
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+
     @Test
     public void createConfig() throws Exception {
-        String cert_data = Utils.wrapCertificate("cert_data");
-        String key_data = Utils.wrapPrivateKey("key_data");
+        String certData = Utils.wrapCertificate("cert_data");
+        String keyData = Utils.wrapPrivateKey("key_data");
         KubernetesAuthCertificate b = new KubernetesAuthCertificate(
-                cert_data,
-                key_data
+                certData,
+                Secret.fromString(keyData)
         );
         io.fabric8.kubernetes.api.model.Config c = Serialization.yamlMapper().readValue(
                 b.buildKubeConfig(new KubernetesAuthConfig("serverUrl", "caCertificate", false)), io.fabric8.kubernetes.api.model.Config.class
         );
 
         // verifying class doesn't modify cert and key data, so not using here
-        assertEquals(Utils.encodeBase64(cert_data), c.getUsers().get(0).getUser().getClientCertificateData());
-        assertEquals(Utils.encodeBase64(key_data), c.getUsers().get(0).getUser().getClientKeyData());
+        assertEquals(Utils.encodeBase64(certData), c.getUsers().get(0).getUser().getClientCertificateData());
+        assertEquals(Utils.encodeBase64(keyData), c.getUsers().get(0).getUser().getClientKeyData());
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/kubernetes/auth/impl/KubernetesAuthKeystoreTest.java
+++ b/src/test/java/org/jenkinsci/plugins/kubernetes/auth/impl/KubernetesAuthKeystoreTest.java
@@ -1,11 +1,14 @@
 package org.jenkinsci.plugins.kubernetes.auth.impl;
 
+import hudson.util.Secret;
 import io.fabric8.kubernetes.api.model.Config;
 import io.fabric8.kubernetes.client.utils.Serialization;
 import org.apache.commons.compress.utils.IOUtils;
 import org.jenkinsci.plugins.kubernetes.auth.KubernetesAuthConfig;
 import org.jenkinsci.plugins.kubernetes.credentials.Utils;
+import org.junit.Rule;
 import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -17,6 +20,8 @@ import java.security.cert.CertificateException;
 import static org.junit.Assert.assertEquals;
 
 public class KubernetesAuthKeystoreTest {
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
 
     protected static final String PASSPHRASE = "test";
 
@@ -24,7 +29,7 @@ public class KubernetesAuthKeystoreTest {
     public void createConfig() throws Exception {
         try (InputStream resourceAsStream = getClass().getResourceAsStream("kubernetes.pkcs12")) {
             KeyStore keyStore = loadKeyStore(resourceAsStream, PASSPHRASE.toCharArray());
-            KubernetesAuthKeystore auth = new KubernetesAuthKeystore(keyStore, PASSPHRASE);
+            KubernetesAuthKeystore auth = new KubernetesAuthKeystore(keyStore, Secret.fromString(PASSPHRASE));
             Config c = Serialization.yamlMapper().readValue(
                     auth.buildKubeConfig(new KubernetesAuthConfig("serverUrl", "caCertificate", false)), Config.class
             );

--- a/src/test/java/org/jenkinsci/plugins/kubernetes/auth/impl/KubernetesAuthUsernamePasswordTest.java
+++ b/src/test/java/org/jenkinsci/plugins/kubernetes/auth/impl/KubernetesAuthUsernamePasswordTest.java
@@ -1,16 +1,22 @@
 package org.jenkinsci.plugins.kubernetes.auth.impl;
 
+import hudson.util.Secret;
 import io.fabric8.kubernetes.client.utils.Serialization;
 import org.jenkinsci.plugins.kubernetes.auth.KubernetesAuthConfig;
 import org.jenkinsci.plugins.kubernetes.auth.impl.KubernetesAuthUsernamePassword;
+import org.junit.Rule;
 import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
 
 import static org.junit.Assert.assertEquals;
 
 public class KubernetesAuthUsernamePasswordTest {
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+
     @Test
     public void createConfig() throws Exception {
-        KubernetesAuthUsernamePassword b = new KubernetesAuthUsernamePassword("user", "pass");
+        KubernetesAuthUsernamePassword b = new KubernetesAuthUsernamePassword("user", Secret.fromString("pass"));
         io.fabric8.kubernetes.api.model.Config c = Serialization.yamlMapper().readValue(
                 b.buildKubeConfig(new KubernetesAuthConfig("serverUrl", "caCertificate", false)), io.fabric8.kubernetes.api.model.Config.class
         );


### PR DESCRIPTION
* use Secret instead of String for storing sensitive data (see https://www.jenkins.io/doc/developer/security/secrets/)
* replace deprecated readFileToString(String) with readFileToString(String, Charset)
* replace deprecated (at)Nonnull with (at)nonnull 