### PR TITLE
Update kubernetes-client-api to 5.4.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <authentication-tokens.version>1.3</authentication-tokens.version>
     <docker-commons.version>1.15</docker-commons.version>
     <google-oauth-plugin.version>0.8</google-oauth-plugin.version>
-    <kubernetes-client-api.version>5.4.1-beta-1</kubernetes-client-api.version>
+    <kubernetes-client-api.version>5.4.1</kubernetes-client-api.version>
 
     <!-- maven plugins versions -->
     <maven-coveralls.version>4.3.0</maven-coveralls.version>
@@ -66,7 +66,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>jackson2-api</artifactId>
-      <version>2.12.1</version>
+      <version>2.12.3</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.2</version>
+    <version>4.18</version>
   </parent>
 
   <groupId>org.jenkinsci.plugins</groupId>
@@ -41,7 +41,7 @@
     <java.level>8</java.level>
 
     <!-- jenkins versions -->
-    <jenkins.version>2.222.1</jenkins.version>
+    <jenkins.version>2.222.4</jenkins.version>
     <bom.artifactId>bom-2.222.x</bom.artifactId>
     <bom.version>9</bom.version>
 
@@ -49,7 +49,7 @@
     <authentication-tokens.version>1.3</authentication-tokens.version>
     <docker-commons.version>1.15</docker-commons.version>
     <google-oauth-plugin.version>0.8</google-oauth-plugin.version>
-    <kubernetes-client-api.version>4.9.2-2</kubernetes-client-api.version>
+    <kubernetes-client-api.version>5.4.1-beta-1</kubernetes-client-api.version>
 
     <!-- maven plugins versions -->
     <maven-coveralls.version>4.3.0</maven-coveralls.version>
@@ -66,7 +66,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>jackson2-api</artifactId>
-      <version>2.11.0</version>
+      <version>2.12.1</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Downstream of https://github.com/jenkinsci/kubernetes-client-api-plugin/releases/tag/kubernetes-client-api-5.4.1

This plugin is not broken by kubernetes-api 5.x api changes. This is a nice to have.

<!-- Please describe your pull request here. -->

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
