### PR TITLE
drop support for Java 8

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 buildPlugin(
     timeout: 10,
     failFast: true,
-    jdkVersions: [8, 11]
+    jdkVersions: [11]
 )


### PR DESCRIPTION
Jenkins has dropped support for Java 8 in recent versions: 
https://www.jenkins.io/blog/2022/06/28/require-java-11/