### PR TITLE
[JENKINS-73610] Allow for null values in "ensureFIPS" methods

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/kubernetes/credentials/Utils.java
+++ b/src/main/java/org/jenkinsci/plugins/kubernetes/credentials/Utils.java
@@ -66,7 +66,10 @@ public abstract class Utils {
      * @throws IllegalArgumentException If the request is invalid
      */
     public static void ensureFIPSCompliantURIRequest(URI uri, boolean skipTLSVerify) {
-        boolean isInsecure = uri.getScheme().equals("http");
+        boolean isInsecure = false;
+        if (uri != null) {
+            isInsecure = "http".equals(uri.getScheme());
+        }
         ensureFIPSCompliant(isInsecure, skipTLSVerify);
     }
 
@@ -82,7 +85,10 @@ public abstract class Utils {
      * @throws IllegalArgumentException If the request is invalid
      */
     public static void ensureFIPSCompliantRequest(String stringRequest, boolean skipTLSVerify) {
-        boolean isInsecure = stringRequest.startsWith("http://");
+        boolean isInsecure = false;
+        if(stringRequest != null) {
+            isInsecure = stringRequest.startsWith("http://");
+        }
         ensureFIPSCompliant(isInsecure, skipTLSVerify);
     }
 

--- a/src/test/java/org/jenkinsci/plugins/kubernetes/credentials/AbstractHttpClientWithTLSOptionsFactoryFIPSTest.java
+++ b/src/test/java/org/jenkinsci/plugins/kubernetes/credentials/AbstractHttpClientWithTLSOptionsFactoryFIPSTest.java
@@ -25,7 +25,13 @@ public abstract class AbstractHttpClientWithTLSOptionsFactoryFIPSTest {
     @Test
     public void testCreateKubernetesAuthConfig() throws URISyntaxException {
         try {
-            HttpClientWithTLSOptionsFactory.getBuilder(new URI(scheme, "localhost", null, null), null, skipTLSVerify);
+            URI uri;
+            if (scheme != null) {
+                uri = new URI(scheme, "localhost", null, null);
+            } else {
+                uri = null;
+            }
+            HttpClientWithTLSOptionsFactory.getBuilder(uri, null, skipTLSVerify);
             if (!shouldPass) {
                 fail("This test was expected to fail, reason: " + motivation);
             }

--- a/src/test/java/org/jenkinsci/plugins/kubernetes/credentials/AbstractOpenShiftBearerTokenCredentialFIPSTest.java
+++ b/src/test/java/org/jenkinsci/plugins/kubernetes/credentials/AbstractOpenShiftBearerTokenCredentialFIPSTest.java
@@ -1,6 +1,7 @@
 package org.jenkinsci.plugins.kubernetes.credentials;
 
 import com.cloudbees.plugins.credentials.CredentialsScope;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
@@ -56,7 +57,7 @@ public abstract class AbstractOpenShiftBearerTokenCredentialFIPSTest {
 
 
     public AbstractOpenShiftBearerTokenCredentialFIPSTest(
-            String scheme, boolean skipTLSVerify, boolean shouldPass, String motivation) {
+            @NonNull String scheme, boolean skipTLSVerify, boolean shouldPass, String motivation) {
         this.scheme = scheme;
         this.skipTLSVerify = skipTLSVerify;
         this.shouldPass = shouldPass;

--- a/src/test/java/org/jenkinsci/plugins/kubernetes/credentials/AbstractUtilsFIPSTest.java
+++ b/src/test/java/org/jenkinsci/plugins/kubernetes/credentials/AbstractUtilsFIPSTest.java
@@ -27,9 +27,32 @@ public abstract class AbstractUtilsFIPSTest {
 
     @Test
     public void ensureFIPSCompliantURIRequest() throws URISyntaxException {
-        HttpUriRequest request = new HttpGet(new URI(scheme, "localhost", null, null));
         try {
-            Utils.ensureFIPSCompliantURIRequest(request.getURI(), skipTLSVerify);
+            if(scheme != null) {
+                HttpUriRequest request = new HttpGet(new URI(scheme, "localhost", null, null));
+                URI uri = request.getURI();
+                Utils.ensureFIPSCompliantURIRequest(uri, skipTLSVerify);
+            } else {
+                Utils.ensureFIPSCompliantURIRequest(null, skipTLSVerify);
+            }
+            if (!shouldPass) {
+                fail("This test was expected to fail, reason: " + motivation);
+            }
+        } catch (IllegalArgumentException e) {
+            if (shouldPass) {
+                fail("This test was expected to pass, reason: " + motivation);
+            }
+        }
+    }
+
+    @Test
+    public void ensureFIPSCompliantRequest() {
+        try {
+            if(scheme != null) {
+                Utils.ensureFIPSCompliantRequest(scheme + "://localhost", skipTLSVerify);
+            } else {
+                Utils.ensureFIPSCompliantRequest(null, skipTLSVerify);
+            }
             if (!shouldPass) {
                 fail("This test was expected to fail, reason: " + motivation);
             }

--- a/src/test/java/org/jenkinsci/plugins/kubernetes/credentials/HttpClientWithTLSOptionsFactoryWithFIPSTest.java
+++ b/src/test/java/org/jenkinsci/plugins/kubernetes/credentials/HttpClientWithTLSOptionsFactoryWithFIPSTest.java
@@ -23,6 +23,7 @@ public class HttpClientWithTLSOptionsFactoryWithFIPSTest extends AbstractHttpCli
     public static Collection<Object[]> parameters() {
         return Arrays.asList(new Object[][] {
             // Valid use cases
+            {null, false, true, "No URL provided and the TLS verification is not skipped, this should be accepted"},
             {"https", false, true, "TLS is used and the TLS verification is not skipped, this should be accepted"},
             // Invalid use cases
             {"https", true, false, "Skip TLS check is not accepted in FIPS mode"},

--- a/src/test/java/org/jenkinsci/plugins/kubernetes/credentials/HttpClientWithTLSOptionsFactoryWithoutFIPSTest.java
+++ b/src/test/java/org/jenkinsci/plugins/kubernetes/credentials/HttpClientWithTLSOptionsFactoryWithoutFIPSTest.java
@@ -23,6 +23,7 @@ public class HttpClientWithTLSOptionsFactoryWithoutFIPSTest extends AbstractHttp
     public static Collection<Object[]> parameters() {
         return Arrays.asList(new Object[][] {
             // Valid use cases
+            {null, false, true, "Not in FIPS mode, any combination should be valid"},
             {"https", false, true, "Not in FIPS mode, any combination should be valid"},
             {"http", false, true, "Not in FIPS mode, any combination should be valid"},
             {"http", true, true, "Not in FIPS mode, any combination should be valid"},

--- a/src/test/java/org/jenkinsci/plugins/kubernetes/credentials/UtilsWithFIPSTest.java
+++ b/src/test/java/org/jenkinsci/plugins/kubernetes/credentials/UtilsWithFIPSTest.java
@@ -22,6 +22,7 @@ public class UtilsWithFIPSTest extends AbstractUtilsFIPSTest {
     public static Collection<Object[]> parameters() {
         return Arrays.asList(new Object[][] {
             // Valid use cases
+            {null, false, true, "No URL provided and the TLS verification is not skipped, this should be accepted"},
             {"https", false, true, "TLS is used and the TLS verification is not skipped, this should be accepted"},
             // Invalid use cases
             {"https", true, false, "Skip TLS check is not accepted in FIPS mode"},

--- a/src/test/java/org/jenkinsci/plugins/kubernetes/credentials/UtilsWithoutFIPSTest.java
+++ b/src/test/java/org/jenkinsci/plugins/kubernetes/credentials/UtilsWithoutFIPSTest.java
@@ -20,6 +20,7 @@ public class UtilsWithoutFIPSTest extends AbstractUtilsFIPSTest {
     @Parameterized.Parameters
     public static Collection<Object[]> parameters() {
         return Arrays.asList(new Object[][] {
+            {null, true, true, "Not in FIPS mode, any combination should be valid"},
             {"https", true, true, "Not in FIPS mode, any combination should be valid"},
             {"https", false, true, "Not in FIPS mode, any combination should be valid"},
             {"http", true, true, "Not in FIPS mode, any combination should be valid"},


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
See [JENKINS-73610](https://issues.jenkins.io/browse/JENKINS-73610)

Fix the `NullPointerException` by allowing `null` value for both `ensureFIPSCompliantURIRequest` and `ensureFIPSCompliantRequest`.

### Testing done

Existing tests have been amended to include a test with a `null` parameter, except for `AbstractOpenShiftBearerTokenCredentialFIPSTest` because a call to `getToken` without an `URL` makes no sense.

I also improved the test coverage by adding a test for `ensureFIPSCompliantRequest`

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] ~Link to relevant pull requests, esp. upstream and downstream changes~
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
